### PR TITLE
feat: update logging to output json for phenix update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Apps written to work with the latest version of
 * Accept stage as single argument.
 * Accept experiment JSON over STDIN.
 * Return updated experiment JSON over STDOUT.
+* Write JSON logs to the file specified by the `PHENIX_LOG_FILE` environment variable.
 
 ## Apps
 

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -5,14 +5,15 @@ go 1.20
 replace phenix => github.com/sandialabs/sceptre-phenix/src/go v0.0.0-20230726231243-4754da61aae8
 
 require (
-	github.com/activeshadow/libminimega v0.0.0-20190412123224-5384445d4b63
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/mitchellh/mapstructure v1.4.0
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	inet.af/netaddr v0.0.0-20220617031823-097006376321
 	phenix v0.0.0-00010101000000-000000000000
 )
 
 require (
+	github.com/activeshadow/libminimega v0.0.0-20190412123224-5384445d4b63 // indirect
 	github.com/activeshadow/structs v1.3.0 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.0.0 // indirect
@@ -42,9 +43,8 @@ require (
 	go.uber.org/zap v1.15.0 // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20230525183740-e7c30c78aeb2 // indirect
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
-	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/grpc v1.27.0 // indirect

--- a/src/go/go.sum
+++ b/src/go/go.sum
@@ -227,8 +227,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -236,7 +236,7 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
+golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -267,8 +267,8 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
@@ -286,11 +286,10 @@ golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
+golang.org/x/tools v0.2.0 h1:G6AHpWxTMGY1KyEYoAQ5WTtIekUUvDNjan3ugu60JvE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/src/go/util/logging.go
+++ b/src/go/util/logging.go
@@ -1,16 +1,15 @@
 package util
 
 import (
+	"golang.org/x/exp/slog"
 	"os"
 	"strings"
-
-	log "github.com/activeshadow/libminimega/minilog"
 )
 
 func SetupLogging() {
 	var (
 		output = os.Stderr
-		level  = log.DefaultLevel
+		level  = slog.LevelInfo
 	)
 
 	if fname := os.Getenv("PHENIX_LOG_FILE"); fname != "" {
@@ -18,20 +17,19 @@ func SetupLogging() {
 
 		output, err = os.OpenFile(os.Getenv("PHENIX_LOG_FILE"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
-			log.AddLogger("stderr", os.Stderr, log.DEBUG, false)
-			log.Fatal("cannot open PHENIX_LOG_FILE (%s) for writing", os.Getenv("PHENIX_LOG_FILE"))
+			slog.Error("cannot open PHENIX_LOG_FILE for writing", "file", os.Getenv("PHENIX_LOG_FILE"))
 		}
 	}
 
 	if lname := os.Getenv("PHENIX_LOG_LEVEL"); lname != "" {
-		var err error
-
-		level, err = log.ParseLevel(strings.ToLower(os.Getenv("PHENIX_LOG_LEVEL")))
+		err := level.UnmarshalText([]byte(strings.ToUpper(os.Getenv("PHENIX_LOG_LEVEL"))))
 		if err != nil {
-			log.AddLogger("stderr", os.Stderr, log.DEBUG, false)
-			log.Fatal("unable to parse PHENIX_LOG_LEVEL (%s)", os.Getenv("PHENIX_LOG_LEVEL"))
+			slog.Error("unable to parse PHENIX_LOG_LEVEL. Expected one of: DEBUG, INFO, WARN, ERROR",
+				"level", os.Getenv("PHENIX_LOG_LEVEL"))
 		}
 	}
 
-	log.AddLogger("default", output, level, false)
+	logger := slog.New(slog.NewJSONHandler(output, &slog.HandlerOptions{Level: level}))
+
+	slog.SetDefault(logger)
 }

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -5,4 +5,4 @@ Apps written in Python to work with latest version of phenix.
 * Accept stage as single argument.
 * Accept experiment JSON over STDIN.
 * Return updated experiment JSON over STDOUT.
-
+* Write JSON logs to the file specified by the `PHENIX_LOG_FILE` environment variable.

--- a/src/python/phenix_apps/common/logger.py
+++ b/src/python/phenix_apps/common/logger.py
@@ -1,11 +1,13 @@
 import inspect
 import logging
 import os
+from typing import Literal
 
 import phenix_apps.common.settings as settings
 
+logger = None
 
-def log(level: str, msg: str) -> None:
+def log(level: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR'] , msg: str) -> None:
     """
     Write a log message to the phenix log.
 
@@ -13,23 +15,22 @@ def log(level: str, msg: str) -> None:
     a message to it.
 
     Args:
-        level (str): Name of logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+        level (str): Name of logging level (DEBUG, INFO, WARNING, ERROR)
         msg (str): Message to write to log
     """
 
     # create phenix logger
-    logger = logging.getLogger('phenix-apps')
-    logger.setLevel(settings.PHENIX_LOG_LEVEL.upper())
+    global logger
+    if logger is None:
+        logger = logging.getLogger('phenix-apps')
+        logger.setLevel(settings.PHENIX_LOG_LEVEL.upper())
 
-    # create handler for phenix logger
-    handler = logging.FileHandler(settings.PHENIX_LOG_FILE)
-    caller = os.path.basename(inspect.stack()[1].filename)
-    formatter = logging.Formatter(
-        f'%(asctime)s %(levelname)8s {caller}:'
-        ' %(message)s', datefmt='%Y/%m/%d %H:%M:%S'
-    )
-    handler.setFormatter(formatter)
+        # create handler for phenix logger
+        handler = logging.FileHandler(settings.PHENIX_LOG_FILE)
+        caller = os.path.basename(inspect.stack()[1].filename)
+        fmt = f'{{"time": "%(asctime)s", "level": "%(levelname)s", "msg": "%(message)s", "caller": "{caller}"}}'
+        handler.setFormatter(logging.Formatter(fmt))
 
-    # add handler to phenix logger
-    logger.handlers[:] = [handler]
+        # add handler to phenix logger
+        logger.handlers[:] = [handler]
     logger.log(getattr(logging, level.upper()), msg)


### PR DESCRIPTION
# feat: update logging to output json for phenix update

## Description
This changes the formatting of logs for both the go and python apps to be json in order to match the new native logging feature for phenix apps in: https://github.com/sandialabs/sceptre-phenix/pull/217

Additionally this makes changes to use `slog` for go (using the exp package like main phenix since we're on `1.20` still)
In python, a single logger instance is created now.

## Type of Change
Please select the type of change your pull request introduces:
- New feature


## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes

Have limited experience with these apps, but did confirm by running the go binary that output was in expected json format. Also added a python app and confirmed in the `configure` state the log showed up in phenix as expected.

**Should be merged in tandem with https://github.com/sandialabs/sceptre-phenix/pull/217**
