### PR TITLE
feat: add helics web api to root broker

### DIFF
--- a/src/python/phenix_apps/apps/helics/helics.py
+++ b/src/python/phenix_apps/apps/helics/helics.py
@@ -118,6 +118,7 @@ class Helics(AppBase):
         log_dir = broker_md.get('log-dir', '/var/log')
 
         root_broker_config = {
+            'name':      root_hostname,
             'subs':      0,
             'feds':      total_fed_count,
             'endpoint':  root_ip,
@@ -140,6 +141,7 @@ class Helics(AppBase):
                 level = fedinfo[1]
 
                 broker_configs.append({
+                    'name':      hostname,
                     'feds':      count,
                     'parent':    root_ip,
                     'endpoint':  endpoint,

--- a/src/python/phenix_apps/apps/helics/templates/broker.mako
+++ b/src/python/phenix_apps/apps/helics/templates/broker.mako
@@ -3,11 +3,12 @@
     if cfg.get('parent', None):
         opts = '--broker {} --local_interface {}'.format(cfg['parent'], cfg['endpoint'])
     elif cfg.get('subs', 0):
-        opts = '--subbrokers {}'.format(cfg['subs'])
+        opts = '--subbrokers {} --web --http_server_args="--http_port=8080 --external"'.format(cfg['subs'])
     else:
         opts = ''
   %>\
 helics_broker \
+  --name ${cfg['name']} \
   ${opts} \
   -f${cfg['feds']} \
   --ipv4 \


### PR DESCRIPTION
# HELICS web api

## Description
Add flag to root broker that exposes the HELICS [web API ](https://docs.helics.org/en/main/user-guide/advanced_topics/webserver.html#rest-api). Also adds broker names using the VM hostname.

## Related Issue
n/a

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [X] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested my code.

## Additional Notes
This enables useful debugging of the HELICS federation.