### PR TITLE
feat(helics): Add wait for broker

### DIFF
--- a/src/python/phenix_apps/apps/helics/templates/wait_broker.mako
+++ b/src/python/phenix_apps/apps/helics/templates/wait_broker.mako
@@ -1,0 +1,5 @@
+#!/bin/bash
+printf "%s" "waiting for root broker"
+time while ! ping -c 1 -n -w 1  ${rootbroker_ip} &> /dev/null; do 
+    printf "%c" "."
+done


### PR DESCRIPTION
# Add wait for broker script to federates

## This PR allows the helics app to inject a "wait for broker" script into all federates. In large experiments on multi-node environments, the federates were coming up before the broker and cause Helics connection failures due to timing issues. 

## Related Issue
n/a

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

