### PR TITLE
fix(ot-sim): backwards compatibility w/ default DNP3 "scan-rate" option

### DIFF
--- a/src/python/phenix_apps/apps/otsim/device.py
+++ b/src/python/phenix_apps/apps/otsim/device.py
@@ -254,9 +254,8 @@ class FieldDeviceClient(Device):
       if 'dnp3' in device.registers:
         client = DNP3()
         client.init_xml_root('client', device.node)
-        if 'scan-rate' in self.configs.keys(): 
-          client.init_master_xml(self.configs['scan-rate'])
-          
+
+        client.init_master_xml(scan_rate = self.configs.get('scan-rate', 5))
         client.registers_to_xml(device.registers['dnp3'])
 
         config.append_to_root(client.root)

--- a/src/python/phenix_apps/apps/otsim/protocols/dnp3.py
+++ b/src/python/phenix_apps/apps/otsim/protocols/dnp3.py
@@ -51,7 +51,7 @@ class DNP3(Protocol):
     endpoint.text = f'{ip}:{port}'
 
 
-  def init_master_xml(self, scan_rate_value, name='dnp3-master'):
+  def init_master_xml(self, name='dnp3-master', scan_rate=5):
     self.master = ET.SubElement(self.root, 'master', {'name': name})
 
     local = ET.SubElement(self.master, 'local-address')
@@ -60,8 +60,9 @@ class DNP3(Protocol):
     remote = ET.SubElement(self.master, 'remote-address')
     remote.text = str(1024)
 
-    scan_rate = ET.SubElement(self.master, 'scan-rate')
-    scan_rate.text = str(scan_rate_value)
+    if scan_rate:
+      rate = ET.SubElement(self.master, 'scan-rate')
+      rate.text = str(scan_rate)
 
 
   def init_outstation_xml(self, name='dnp3-outstation'):


### PR DESCRIPTION
# Backwards Compatibility for DNP3 Master `scan-rate` Option

## Description

Commit 55d84615 introduced the option to specify a scan rate for DNP3 masters, but did not correctly support the option being missing, breaking backwards compatibility.

## Related Issue

#72

## Type of Change

Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes

@tijcolem please do me a favor and test to see if this addresses your issue #72.