### PR TITLE
fix(protonuke): update Windows template to assume existence of scheduled task

### DIFF
--- a/src/python/phenix_apps/apps/protonuke/protonuke.py
+++ b/src/python/phenix_apps/apps/protonuke/protonuke.py
@@ -27,14 +27,14 @@ class Protonuke(AppBase):
             if vm.topology.hardware.os_type.upper() == 'WINDOWS':
                 kwargs = {
                     'src' : path,
-                    'dst' : '/ProgramData/Microsoft/Windows/Start Menu/Programs/Startup/protonuke-scheduler.cmd',
+                    'dst' : '/phenix/startup/90-protonuke.ps1',
                 }
 
                 templates = utils.abs_path(__file__, 'templates/')
 
                 with open(path, 'w') as f:
                     utils.mako_serve_template(
-                        'protonuke_scheduler.mako', templates, f, protonuke_args=vm.metadata.args
+                        'protonuke.ps1.mako', templates, f, protonuke_args=vm.metadata.args
                     )
             else:
                 kwargs = {

--- a/src/python/phenix_apps/apps/protonuke/templates/protonuke.ps1.mako
+++ b/src/python/phenix_apps/apps/protonuke/templates/protonuke.ps1.mako
@@ -1,0 +1,1 @@
+Start-Job -ScriptBlock { C:\minimega\protonuke.exe ${protonuke_args} }

--- a/src/python/phenix_apps/apps/protonuke/templates/protonuke_scheduler.mako
+++ b/src/python/phenix_apps/apps/protonuke/templates/protonuke_scheduler.mako
@@ -1,2 +1,0 @@
-schtasks /create /tn "protonuke" /sc onlogon /rl highest /tr "C:\minimega\protonuke.exe ${protonuke_args}" /F
-schtasks /run /tn "protonuke"


### PR DESCRIPTION
# Pull Request Title
fix(protonuke): update Windows template to assume existence of scheduled task

## Description
Windows template was assuming old way of starting processes in Windows VMs using the startup folder. This now creates a PowerShell script inject that will be processed by the scheduled task assumed to be in all Windows VMs these days.

Note that this template still assumes the protonuke executable is located at `C:\minimega\protonuke.exe`.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A