### PR TITLE
fix(scorch): pcap dedupe and merge improvements

### DIFF
--- a/src/python/phenix_apps/common/utils.py
+++ b/src/python/phenix_apps/common/utils.py
@@ -636,8 +636,8 @@ def mm_delete_file(
         raise ValueError(f"unknown os_type '{os_type}' for mm_delete_file with filter '{cc_filter}'")
 
 
-def run_command(cmd: str) -> str:
-    result = subprocess.check_output(cmd, shell=True)
+def run_command(cmd: str, timeout: Optional[float] = None) -> str:
+    result = subprocess.check_output(cmd, shell=True, timeout=timeout)
     if isinstance(result, bytes):
         result = result.decode()
     return result


### PR DESCRIPTION
# fix(scorch): pcap dedupe and merge improvements

## Description
- Add timeout to commands to handle cases where `tshark` hangs excessively due to bad packets.
- Use intermediate temp pcap when merging, so failed merges can be investigated.
- Add validation for dedupe and merge that they actually finished and generated files.
- Add special deduplication to handle DoS packets generated by packet flood disruption scenarios.
- Add optional timeout flag to `utils.run_command()`

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
zilch