### PR TITLE
fix(protonuke): run protonuke as hidden process in Windows

### DIFF
--- a/src/python/phenix_apps/apps/protonuke/templates/protonuke.ps1.mako
+++ b/src/python/phenix_apps/apps/protonuke/templates/protonuke.ps1.mako
@@ -1,1 +1,1 @@
-Start-Job -ScriptBlock { C:\minimega\protonuke.exe ${protonuke_args} }
+Start-Process -WindowStyle Hidden -FilePath "C:\minimega\protonuke.exe" -ArgumentList "${protonuke_args}"


### PR DESCRIPTION
# Run protonuke as hidden process in Windows

## Description
The Windows SYSTEM user cannot start background jobs, so run protonuke as a hidden process instead.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
N/A