### PR TITLE
feat(cc): add exec with filter as stage-level commmand

### DIFF
--- a/src/python/phenix_apps/apps/scorch/cc/README.md
+++ b/src/python/phenix_apps/apps/scorch/cc/README.md
@@ -14,7 +14,8 @@ metadata:
   # Commands (types) to run for a particular stage (configure, start, stop, cleanup)
   # NOTE: The stage-level types differ from the VM-level types
   configure:
-    - type: reset  # delete all miniccc commands and responses
+    - type: reset # delete all miniccc commands and responses
+    - type: exec # run 'cc exec' with arguments targeting VMs using a cc filter
   start: [] # same array of keys as above
   stop: [] # same array of keys as above
   cleanup: [] # same array of keys as above
@@ -45,6 +46,7 @@ metadata:
   - `recv`: receive a file (VM -> Host)
 - Stage-level command types
   - `reset`: reset miniccc state, by clearing filter and deleting all commands and responses. **WARNING**: THIS WILL INTERFERE WITH OPERATION OF MANY COMPONENTS! Reset should only be used at the start or end of a run or a loop (use with special care in loops!).
+  - `exec`: execute a command (`cc exec`). Currently the only supported arguments for this stage-level command are `once` and `filter_`
 
 ## Notes on the `exec` and `background` Type
 
@@ -92,9 +94,17 @@ components:
     type: cc
     metadata:
       configure:
-        - reset
+        - type: reset
       cleanup:
-        - reset
+        - type: reset
+  - name: stage_exec
+    type: cc
+    metadata:
+      start:
+        - type: exec
+          filter: tag=foo:bar
+          args: service foobar restart
+          once: true
   - name: disable-eth0
     type: cc
     metadata:

--- a/src/python/phenix_apps/apps/scorch/cc/cc.py
+++ b/src/python/phenix_apps/apps/scorch/cc/cc.py
@@ -33,6 +33,18 @@ class CC(ComponentBase):
         for cmd in commands:
             if cmd.type == 'reset':
                 self.__reset_cc()
+            elif cmd.type == 'exec':
+                once = cmd.get('once', True)
+                filter_ = cmd.get('filter', None)
+                if filter_:
+                    self.mm.cc_filter(filter_)
+
+                if once:
+                    self.mm.cc_exec_once(cmd.args)
+                else:
+                    self.mm.cc_exec(cmd.args)
+
+                self.print(f"command '{cmd.args}' executed with filter '{filter_}' using cc")
             else:
                 self.eprint(f"Unknown command type '{cmd.type}' for stage '{stage}'")
                 sys.exit(1)


### PR DESCRIPTION
# Pull Request Title
SCORCH cc exec with filter

## Description
This PR adds the ability to specify a stage-level exec command that uses a cc filter to target multiple VMs at the same time.

## Related Issue
n/a

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [X] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested my code.

## Additional Notes
E.g.

```yaml
    - name: scorch
      metadata:
        components:
          - name: foobar
            type: cc
            metadata:
              start:
              - type: exec
                filter: tag=foo:bar
                args: service foobar restart
                once: true
```
