### PR TITLE
feat: alternative scada server automation

### DIFF
--- a/src/python/phenix_apps/apps/sceptre/sceptre.py
+++ b/src/python/phenix_apps/apps/sceptre/sceptre.py
@@ -184,14 +184,16 @@ class Sceptre(AppBase):
                     "description": "SCADA project file",
                 }
                 self.add_inject(hostname=scada_server.hostname, inject=kwargs)
-
-                # Create automation injection
-                kwargs = {
-                    "src": f"{scada_server.metadata.automation}",
-                    "dst": "myscada.exe",
-                    "description": "Windows automation binary",
-                }
-                self.add_inject(hostname=scada_server.hostname, inject=kwargs)
+    
+                # If given an automation executatble, use that. Else, the scada.mako will use alternative automation
+                if 'automation' in scada_server.metadata:
+                    # Create automation injection
+                    kwargs = {
+                        "src": f"{scada_server.metadata.automation}",
+                        "dst": "myscada.exe",
+                        "description": "Windows automation binary",
+                    }
+                    self.add_inject(hostname=scada_server.hostname, inject=kwargs)
             
                 # Create startup script injection
                 kwargs = self.find_override(f"{scada_server.hostname}_scada.ps1")

--- a/src/python/phenix_apps/apps/sceptre/templates/scada.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/scada.mako
@@ -13,8 +13,172 @@ function Phenix-StartupComplete {
 
   return $false
 }
+
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+public class Mouse
+{
+    [DllImport("user32.dll")]
+    public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, UIntPtr dwExtraInfo);
+
+    [DllImport("user32.dll")]
+    public static extern bool SetCursorPos(int X, int Y);
+
+    private const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+    private const uint MOUSEEVENTF_LEFTUP = 0x0004;
+    private const uint MOUSEEVENTF_RIGHTDOWN = 0x0008;
+    private const uint MOUSEEVENTF_RIGHTUP = 0x0010;
+
+    public static void LeftClick(int x, int y)
+    {
+        SetCursorPos(x, y);
+        mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, UIntPtr.Zero);
+        mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, UIntPtr.Zero);
+    }
+
+    public static void RightClick(int x, int y)
+    {
+        SetCursorPos(x, y);
+        mouse_event(MOUSEEVENTF_RIGHTDOWN, 0, 0, 0, UIntPtr.Zero);
+        mouse_event(MOUSEEVENTF_RIGHTUP, 0, 0, 0, UIntPtr.Zero);
+   }
+}
+"@
+
 while (-Not (Phenix-StartupComplete)) {
     Start-Sleep -s 30
 }
 
-C:\myscada.exe
+$automation_filepath = "C:\myscada.exe"
+
+if (Test-Path $automation_filepath) {
+    # If the file exists, execute the command
+    & $automation_filepath
+} else {
+    # If the file does not exist, use alternative automation
+    Echo "opening myDESIGNER"
+    # Open mydesigner
+    Start-Process "C:\Program Files\myDESIGNER7\bin\mydesigner.exe" "--console new"
+
+    Echo 'sleeping'
+    # Wait for the mydesigner window to open
+    Start-Sleep 90
+
+    # Select "Import Project"
+    $mydesigner = Select-Window -Active
+    Start-Sleep 1
+    $mydesigner | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $mydesigner | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $mydesigner | Send-Keys "{Enter}"
+    Start-Sleep 1
+
+    # Open "import.mep"
+    Echo "opening autoproject"
+    $select_win = Select-Window -Active
+    Start-Sleep 1
+    $select_win | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{Enter}"
+    Start-Sleep 1
+    $select_win | Send-Keys "C:/Users/wwuser/Documents/Configs/Inject/"
+    Start-Sleep 1
+    $select_win | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{Enter}"
+    Start-Sleep 1
+    $select_win | Send-Keys "myscada.mep"
+    Start-Sleep 1
+    $select_win | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{Enter}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{Enter}"
+    Start-Sleep 10
+
+    # Select "Download to Devices" button using menus
+    $select_win = Select-Window -Active
+    Start-Sleep 1
+    $select_win | Send-Keys "{F10}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{RIGHT}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{DOWN}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{RIGHT}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{DOWN}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{DOWN}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{DOWN}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{DOWN}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{DOWN}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{DOWN}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{DOWN}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{DOWN}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{ENTER}"
+    Start-Sleep 1
+
+    # Checkbox for "This Computer"  
+    # This is a hack...the checkbox is not accessible through any keyboard commands :(
+    Echo "Hitting download"
+    Start-Sleep 1
+    #the real hack
+    [Mouse]::LeftClick(28, 122)
+
+    # Hit "Download to Devices" button
+    $select_win = Select-Window -Active
+    Start-Sleep 1
+    $select_win | Send-Keys "+{TAB}" #we get stuck in the pane so we need to SHFT-TAB instead of just TAB
+    Start-Sleep 1
+    $select_win | Send-Keys "+{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "+{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "+{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{ENTER}"
+
+    # Wait for stuff to load
+    Start-Sleep 30
+
+    # Hit "Download to Devices" button
+    Start-Sleep 1
+    $select_win | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{TAB}"
+    Start-Sleep 1
+    $select_win | Send-Keys "{ENTER}"
+
+    # Hit "Yes" button
+    Start-Sleep 10
+    $select_win | Send-Keys "{ENTER}"
+
+    # Hit "Ok" button
+    Start-Sleep 10
+    $select_win | Send-Keys "{ENTER}"
+}


### PR DESCRIPTION
# Alternative SCADA Server automation

## Description
If the metadata for a SCADA server does not include the `automation` field with the automation executable, then the alternative automation contained in `scada.mako` will be used. 

## Related Issue
NA
## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
NA