### PR TITLE
Feat: SCEPTRE app updates for python provider

### DIFF
--- a/src/python/phenix_apps/apps/sceptre/app.py
+++ b/src/python/phenix_apps/apps/sceptre/app.py
@@ -424,6 +424,26 @@ class Sceptre(AppBase):
                 }
                 self.add_inject(hostname=provider.hostname, inject=kwargs)
 
+            # Create Python provider injections
+            elif simulator == "GenericPython":
+                # config
+                kwargs = self.find_override(f"{provider.hostname}_config.ini")
+                if kwargs is None:
+                    kwargs = {"src": f"{vm_directory}/config.ini"}
+                kwargs.update({
+                    "dst": "/etc/sceptre/config.ini",
+                    "description": "Python provider config",
+                })
+                self.add_inject(hostname=provider.hostname, inject=kwargs)
+
+                # simulation file
+                kwargs = {
+                    "src": f"{provider.metadata.simulation_file}",
+                    "dst": f"/etc/sceptre/simulation.py",
+                    "description": "Python simulation file",
+                }
+                self.add_inject(hostname=provider.hostname, inject=kwargs)
+
             # Create default provider injections
             else:
                 # config

--- a/src/python/phenix_apps/apps/sceptre/configs/configs.py
+++ b/src/python/phenix_apps/apps/sceptre/configs/configs.py
@@ -24,6 +24,8 @@ def get_fdconfig_class(infrastructure: str) -> type:
         base_class = infra.WaterwayInfrastructure
     elif infrastructure == 'battery':
         base_class = infra.BatteryInfrastructure
+    elif infrastructure == 'generic':
+        base_class = infra.GenericInfrastructure
     else:
         raise error.AppError(f"Infrastructure: {infrastructure} not supported")
 

--- a/src/python/phenix_apps/apps/sceptre/configs/infrastructures.py
+++ b/src/python/phenix_apps/apps/sceptre/configs/infrastructures.py
@@ -565,6 +565,41 @@ class BatteryInfrastructure(Infrastructure):
 
         return Device(device_type, device_name, protocol, reg_config, **device_kwargs)
 
+class GenericInfrastructure(Infrastructure):
+    """Generic infrastructure.
+    Useful when you don't want to have to define explicit devices and fields. """
+    def __init__(self):
+        super().__init__()
+        super().register('generic')
+        self.range = -32767.0, 32767.0
+
+    @staticmethod
+    def create_device(device_type, device_name, protocol, reg_config, **kwargs):
+        if type(device_type) == str and device_type.lower() == 'analog-read':
+            device_kwargs = {
+                'range': (-32767.0, 32767.0),
+                'analog-read': kwargs.get('analog-read', ['value']),
+            }
+            return Device(device_type, device_name, protocol, reg_config, **device_kwargs)
+        elif type(device_type) == str and device_type.lower() == 'analog-read-write':
+            device_kwargs = {
+                'range': (-32767.0, 32767.0),
+                'analog-read-write': kwargs.get('analog-read-write', ['value']),
+            }
+            return Device(device_type, device_name, protocol, reg_config, **device_kwargs)
+        elif type(device_type) == str and device_type.lower() == 'binary-read':
+            device_kwargs = {
+                'range': (0, 1000),
+                'binary-read': kwargs.get('binary-read', ['status']),
+            }
+            return Device(device_type, device_name, protocol, reg_config, **device_kwargs)
+        elif type(device_type) == str and device_type.lower() == 'binary-read-write':
+            device_kwargs = {
+                'range': (0, 1000),
+                'binary-read-write': kwargs.get('binary-read-write', ['status']),
+            }
+            return Device(device_type, device_name, protocol, reg_config, **device_kwargs)
+
 
 class Device(Infrastructure):
     def __init__(self, device_type, device_name, protocol, reg_config, **kwargs):

--- a/src/python/phenix_apps/apps/sceptre/templates/provider_config.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/provider_config.mako
@@ -29,3 +29,6 @@ case-file         = /etc/sceptre/${case_file}
 % if solver in ['RTDS', 'OPALRT'] or config_file:
 config-file       = ${config_file}
 % endif
+% if solver == 'GenericPython':
+simulation-file = /etc/sceptre/simulation.py
+% endif

--- a/src/python/phenix_apps/apps/sceptre/templates/sceptre_start.mako
+++ b/src/python/phenix_apps/apps/sceptre/templates/sceptre_start.mako
@@ -19,7 +19,7 @@ bennu-simulink-provider --server-endpoint '${server_endpoint}' --publish-endpoin
         % endif
     % elif metadata.get('simulator','').lower() == 'alicanto':
 pybennu-alicanto -c /etc/sceptre/alicanto.json -d DEBUG > /etc/sceptre/log/alicanto.log 2>&1 &
-    % elif 'provider' in name.lower() or metadata.get('simulator', '').lower().startswith('powerworld') or metadata.get('simulator', '').lower() in ['pypower', 'siren', 'opalrt', 'rtds']:
+    % elif 'provider' in name.lower() or metadata.get('simulator', '').lower().startswith('powerworld') or metadata.get('simulator', '').lower() in ['pypower', 'siren', 'opalrt', 'rtds', 'genericpython']:
         % if needsleep:
 sleep 60s
         % endif


### PR DESCRIPTION
# SCEPTRE app updates to integrate new python provider capability 

## Description
* Added "python provider" check in the SCEPRE app to inject associated config and simulation files
* Added "python provider" section to the `provider_config.mako` to create the necessary config for a python provider
* Added "python provider" section to the `sceptre_start.mako` to start the python provider on startup
* Added the `generic` infrastructure to make modeling more flexible  

## Related Issue
NA

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
* Relates to https://github.com/sandialabs/sceptre-bennu/pull/47
* Docs are under review and coming soon.