### PR TITLE
fix(scorch): make Kafka component run in config and cleanup stages

### DIFF
--- a/src/python/phenix_apps/apps/scorch/kafka/README.md
+++ b/src/python/phenix_apps/apps/scorch/kafka/README.md
@@ -1,5 +1,6 @@
 # phenix (kafka) Component
 Collects and filters desired Kafka data into CSV/JSON format, so that Kafka data can be easily used by programs such as Excel. The output directory for the data is listed in the phenix log when the scorch component starts.
+This component is called in the configure and cleanup stages.
 
 ```
 type: kafka
@@ -38,4 +39,15 @@ metadata:
           - key: name
             value: bar* # Wildcards work for values
         name: ${BRANCH_NAME}.foo.bar2
+```
+
+## Example Pipeline
+
+```yaml
+runs:
+  - name: kafka_pipeline
+    configure:
+      - kafka
+    cleanup:
+      - kafka
 ```


### PR DESCRIPTION
# Pull Request Title
make Kafka component run in config and cleanup stages

## Description
Previously, the configure stage just called the start stage and users that listed Kafka in the configure and start stages would start the component twice. There was a check to ensure that the component didn't start more than once; however, that check didn't actually work. Now I make the component only work in the configure and cleanup stages. I also use deterministic pid names so that you can run multiple kafka components at the same time without overwriting the pid file.

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Please provide any additional information or context for your pull request here.
