### PR TITLE
fix(scorch): re-add ComponentBase to scorch __init__.py

### DIFF
--- a/src/python/phenix_apps/apps/scorch/__init__.py
+++ b/src/python/phenix_apps/apps/scorch/__init__.py
@@ -1,0 +1,1 @@
+from .app import ComponentBase as ComponentBase


### PR DESCRIPTION
# fix(scorch): re-add ComponentBase to scorch __init__.py

## Description
scorch `__init__.py` is called before each scorch _component_, and each of these requires importing `ComponentBase` to function.

## Related Issue
Reversion caused in #87 (mea culpa) 

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- ~I have commented my code, particularly in hard-to-understand areas.~
- ~I have made corresponding changes to the documentation.~
- ~My changes generate no new warnings.~
- [X] I have tested my code.

## Additional Notes
N/A