### PR TITLE
fix(scorch): removing depreciated self.print and self.eprint

### DIFF
--- a/src/python/phenix_apps/apps/scorch/app.py
+++ b/src/python/phenix_apps/apps/scorch/app.py
@@ -240,7 +240,7 @@ class ComponentBase:
     def es(self) -> Elasticsearch:
         """Connect to Elasticsearch and return the initialized object."""
         if not self._es:
-            self.print(
+            logger.info(
                 f"Connecting to Elasticsearch: {self.metadata.elasticsearch.server}"
             )
             self._es = utils.connect_elastic(self.metadata.elasticsearch.server)
@@ -285,8 +285,7 @@ class ComponentBase:
         for app in self.experiment.spec.scenario.apps:
             if app.name == name:
                 return app
-        self.eprint(f"failed to find app '{name}'")
-        return None
+        raise ValueError(f"failed to find app '{name}'")
 
     def extract_node(
         self, hostname: str, wildcard: bool = False
@@ -375,18 +374,18 @@ class ComponentBase:
         elif not dst and isinstance(src, list):
             dst = self.base_dir
 
-        self.print(f"copying file from {vm} (src={src}, dst={dst})")
+        logger.info(f"copying file from {vm} (src={src}, dst={dst})")
 
         try:
             utils.mm_recv(self.mm, vm, src, dst)
-            self.print(f"file '{src}' received from VM {vm} to {dst}")
+            logger.info(f"file '{src}' received from VM {vm} to {dst}")
         except Exception as ex:
             raise RuntimeError(
                 f"error receiving file '{src}' from VM {vm}: {ex}"
             ) from ex
 
     def ensure_vm_running(self, vm: str) -> None:
-        self.print(f"Checking if VM is running (VM hostname: {vm})")
+        logger.info(f"Checking if VM is running (VM hostname: {vm})")
         vm_info = utils.mm_info_for_vm(self.mm, vm)
         if not vm_info or vm_info["state"].lower() != "running":
             raise RuntimeError(f"VM isn't running (vm name: {vm})")
@@ -435,7 +434,7 @@ class ComponentBase:
 
         if process.lower() in ps_list.lower():
             return True
-        self.eprint(f"process '{process}' is not running on '{vm}'")
+        logger.info(f"process '{process}' is not running on '{vm}'")
         return False
 
     def configure(self) -> None:


### PR DESCRIPTION
# scorch: removing depreciated self.print and self.eprint

## Description
Removed self.print and self.eprint funcitons from scorch app and replaced with logger.info and raise exceptions as a consequence of the new centralized phenix logging. 

## Related Issue

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
NA