### PR TITLE
fix(mirror): don't return error on success

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,8 +1,7 @@
 name: codespell
 
 on:
-  push:
-    branches: [ "**" ]
+  pull_request:
 
 jobs:
   codespell:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,12 +4,17 @@ env:
   GO_VERSION: 1.24.0
 
 on:
-  push:
-    branches: ['**']
+  pull_request:
+    branches: [ "**" ]
+    paths:
+      - 'src/go/**.go'
+      - 'src/go/go.mod'
+      - 'src/go/go.sum'
+      - '.github/workflows/go.yml'
 
 jobs:
 
-  lint-check:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -36,4 +41,4 @@ jobs:
           cache-dependency-path: src/go/go.sum
       - name: Run Tests
         working-directory: src/go
-        run: make test
+        run: make coverage

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,12 +4,15 @@ env:
   PYTHON_VERSION: "3.12"
 
 on:
-  push:
-    branches: ['**']
+  pull_request:
+    branches: [ "**" ]
+    paths:
+      - 'src/python/**.py'
+      - '.github/workflows/python.yml'
 
 jobs:
 
-  lint-check:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -14,7 +14,7 @@ help:
 	@echo "Development:"
 	@echo "  all         - Run all tools (format, lint, and test)"
 	@echo "  check       - Run linters without fixing (for CI)"
-	@echo "  coverage       - Run unit tests with coverage"
+	@echo "  coverage    - Run unit tests with coverage"
 	@echo "  format      - Format code (golangci-lint)"
 	@echo "  lint        - Lint code and fix issues (golangci-lint)"
 	@echo "  lint-clean  - Clean lint cache (golangci-lint)"
@@ -46,7 +46,7 @@ install:
 
 install-dev:
 	$(call check-command,curl)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(GOBIN) v2.10.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(GOBIN) v2.11.3
 
 format:
 	$(call check-command,$(GOLANGCI_LINT))

--- a/src/go/cmd/phenix-app-mirror/main.go
+++ b/src/go/cmd/phenix-app-mirror/main.go
@@ -771,17 +771,14 @@ func cleanup(log *slog.Logger, exp *types.Experiment, dryrun bool) error {
 }
 
 func deleteTap(log *slog.Logger, name, exp string, cluster map[string][]string) error {
-	var errs error
+	var errs *multierror.Error
 
 	for host := range cluster {
 		errs = multierror.Append(errs, deleteTapFromHost(log, name, exp, host))
 	}
 
-	if errs != nil {
-		return fmt.Errorf("error deleting tap: %w", errs)
-	}
-
-	return nil
+	//nolint:wrapcheck // multierror already wraps errors
+	return errs.ErrorOrNil()
 }
 
 func deleteTapFromHost(log *slog.Logger, name, exp, host string) error {
@@ -801,23 +798,20 @@ func deleteTapFromHost(log *slog.Logger, name, exp, host string) error {
 }
 
 func deleteMirror(log *slog.Logger, mirror, bridge string, cluster map[string][]string) error {
-	var errs error
+	var errs *multierror.Error
 
 	for host := range cluster {
 		errs = multierror.Append(errs, deleteMirrorFromHost(log, mirror, bridge, host))
 	}
 
-	if errs != nil {
-		return fmt.Errorf("error deleting mirror: %w", errs)
-	}
-
-	return nil
+	//nolint:wrapcheck // multierror already wraps errors
+	return errs.ErrorOrNil()
 }
 
 func deleteMirrorFromHost(log *slog.Logger, mirror, bridge, host string) error {
 	log.Info("deleting mirror", "mirror", mirror, "bridge", bridge, "host", host)
 
-	var errs error
+	var errs *multierror.Error
 
 	cmd := fmt.Sprintf(
 		`ovs-vsctl -- --id=@m get mirror %s -- remove bridge %s mirrors @m`,
@@ -854,11 +848,8 @@ func deleteMirrorFromHost(log *slog.Logger, mirror, bridge, host string) error {
 		)
 	}
 
-	if errs != nil {
-		return fmt.Errorf("error deleting mirror from host: %w", errs)
-	}
-
-	return nil
+	//nolint:wrapcheck // multierror already wraps errors
+	return errs.ErrorOrNil()
 }
 
 func mirrorNet(log *slog.Logger, md *MirrorAppMetadataV1) (netaddr.IPPrefix, error) {

--- a/src/go/version/version.go
+++ b/src/go/version/version.go
@@ -1,4 +1,3 @@
-//nolint:revive // version is a common package name, conflict with go/version is acceptable
 package version
 
 const Version = "2.0.0"


### PR DESCRIPTION
# fix(mirror): don't return error on success

## Description
Update mirror app cleanup so that multierror doesn't return "0 errors" and cause phenix to think it failed.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix
- ~New feature~
- ~Documentation update~
- ~Other (please describe):~

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- ~I have commented my code, particularly in hard-to-understand areas.~
- ~I have made corresponding changes to the documentation.~
- [X] My changes generate no new warnings.
- [X] I have tested my code.

## Additional Notes
Also fix all the actions Casey broke.