### PR TITLE
fix(mm): add stability for mm actions across hosts

### DIFF
--- a/src/python/phenix_apps/apps/scorch/art/art.py
+++ b/src/python/phenix_apps/apps/scorch/art/art.py
@@ -40,11 +40,11 @@ class AtomicRedTeam(ComponentBase):
             shell_cmd = f"test -x {goart_path}"
         try:
             utils.mm_exec_wait(mm, hostname, shell_cmd)
-        except Exception:
+        except Exception as ex:
             raise RuntimeError(
                 f"goart not found or not executable at {goart_path} on {hostname}. "
                 f"Ensure it is injected via topology."
-            )
+            ) from ex
 
     def start(self):
         logger.info(f"Starting user component: {self.name}")

--- a/src/python/phenix_apps/apps/scorch/caldera/caldera.py
+++ b/src/python/phenix_apps/apps/scorch/caldera/caldera.py
@@ -73,11 +73,8 @@ class Caldera(ComponentBase):
                 )
 
             mm.cc_filter(f"name={server}")
-            mm.cc_send(cmd_src)
-
-            # wait for file to be sent via cc
-            last_cmd = utils.mm_last_command(mm)
-            utils.mm_wait_for_cmd(mm, last_cmd["id"])
+            cmd_id = utils.mm_command_id(mm.cc_send(cmd_src))
+            utils.mm_wait_for_cmd(mm, cmd_id)
 
             os.remove(cmd_src)
 
@@ -115,11 +112,8 @@ class Caldera(ComponentBase):
                 )
 
             mm.cc_filter(f"name={server}")
-            mm.cc_send(cmd_src)
-
-            # wait for file to be sent via cc
-            last_cmd = utils.mm_last_command(mm)
-            utils.mm_wait_for_cmd(mm, last_cmd["id"])
+            cmd_id = utils.mm_command_id(mm.cc_send(cmd_src))
+            utils.mm_wait_for_cmd(mm, cmd_id)
 
             os.remove(cmd_src)
 
@@ -157,11 +151,8 @@ class Caldera(ComponentBase):
                 )
 
             mm.cc_filter(f"name={server}")
-            mm.cc_send(cmd_src)
-
-            # wait for file to be sent via cc
-            last_cmd = utils.mm_last_command(mm)
-            utils.mm_wait_for_cmd(mm, last_cmd["id"])
+            cmd_id = utils.mm_command_id(mm.cc_send(cmd_src))
+            utils.mm_wait_for_cmd(mm, cmd_id)
 
             os.remove(cmd_src)
 
@@ -193,11 +184,8 @@ class Caldera(ComponentBase):
             utils.mako_serve_template("new_operation.mako", templates, f, op=op)
 
         mm.cc_filter(f"name={server}")
-        mm.cc_send(cmd_src)
-
-        # wait for file to be sent via cc
-        last_cmd = utils.mm_last_command(mm)
-        utils.mm_wait_for_cmd(mm, last_cmd["id"])
+        cmd_id = utils.mm_command_id(mm.cc_send(cmd_src))
+        utils.mm_wait_for_cmd(mm, cmd_id)
 
         os.remove(cmd_src)
 
@@ -221,11 +209,8 @@ class Caldera(ComponentBase):
                 )
 
             mm.cc_filter(f"name={server}")
-            mm.cc_send(cmd_src)
-
-            # wait for file to be sent via cc
-            last_cmd = utils.mm_last_command(mm)
-            utils.mm_wait_for_cmd(mm, last_cmd["id"])
+            cmd_id = utils.mm_command_id(mm.cc_send(cmd_src))
+            utils.mm_wait_for_cmd(mm, cmd_id)
 
             os.remove(cmd_src)
 
@@ -252,11 +237,8 @@ class Caldera(ComponentBase):
             )
 
         mm.cc_filter(f"name={server}")
-        mm.cc_send(cmd_src)
-
-        # wait for file to be sent via cc
-        last_cmd = utils.mm_last_command(mm)
-        utils.mm_wait_for_cmd(mm, last_cmd["id"])
+        cmd_id = utils.mm_command_id(mm.cc_send(cmd_src))
+        utils.mm_wait_for_cmd(mm, cmd_id)
 
         os.remove(cmd_src)
 

--- a/src/python/phenix_apps/apps/scorch/cc/cc.py
+++ b/src/python/phenix_apps/apps/scorch/cc/cc.py
@@ -252,11 +252,8 @@ class CC(ComponentBase):
             f.write(cmd)
 
         self.mm.cc_filter(f"name={hostname}")
-        self.mm.cc_send(cmd_src)
-
-        # wait for file to be sent via cc
-        last_cmd = utils.mm_last_command(self.mm)
-        utils.mm_wait_for_cmd(self.mm, last_cmd["id"])
+        cmd_id = utils.mm_command_id(self.mm.cc_send(cmd_src))
+        utils.mm_wait_for_cmd(self.mm, cmd_id)
         self.mm.clear_cc_filter()
 
         os.remove(cmd_src)

--- a/src/python/phenix_apps/common/tests/test_utils.py
+++ b/src/python/phenix_apps/common/tests/test_utils.py
@@ -1,0 +1,137 @@
+import minimega
+import pytest
+
+from phenix_apps.common import utils
+
+
+# Derive the transient and permanent cases from the lists in utils.py
+@pytest.mark.parametrize("token", utils._MM_TRANSIENT)
+def test_transient_tokens_classify_transient(token):
+    assert utils.is_transient_mm_error(minimega.Error(token)) is True
+
+
+@pytest.mark.parametrize("token", utils._MM_PERMANENT)
+def test_permanent_tokens_classify_permanent(token):
+    assert utils.is_transient_mm_error(minimega.Error(token)) is False
+
+
+# Cases not in the lists
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # Transient wrapped
+        ("unable to get exit code: no client foo", True),
+        # Permanent wrapped
+        ("no such handler: can't handle this", False),
+        # Permanent + transient -> permanent wins
+        (
+            "vm not running: connection reset by peer",
+            False,
+        ),
+        # Not in either list -> default False
+        (
+            "something that does not exist in either list",
+            False,
+        ),
+    ],
+)
+def test_is_transient_mm_error_messages(text, expected):
+    assert utils.is_transient_mm_error(minimega.Error(text)) is expected
+
+
+class _StubMM:
+    """Stand-in for minimega.minimega whose cc_exitcode replays per-call effects:
+    a list (the per-host rows that cc fan-out returns) is returned, an Exception
+    is raised (a transport-level failure). Mirrors _raise_errors so
+    mm_cc_all_hosts can toggle it."""
+
+    def __init__(self, effects):
+        self._effects = list(effects)
+        self._raise_errors = True
+        self.calls = 0
+
+    def cc_exitcode(self, *_args):
+        self.calls += 1
+        effect = self._effects.pop(0)
+
+        if isinstance(effect, Exception):
+            raise effect
+
+        return effect
+
+
+# Multi-host cc_exitcode fan-out: the sibling host that doesn't run the VM
+# reports "no client"; only the VM's host carries the code.
+_SIBLING_ONLY = [{"Host": "gibson1337", "Error": "no client foo", "Response": ""}]
+_WITH_CODE = [
+    {"Host": "gibson1337", "Error": "no client foo", "Response": ""},
+    {"Host": "gibson1336", "Error": "", "Response": "0"},
+]
+
+
+def test_mm_cc_all_hosts_returns_all_rows_and_restores_raise_errors():
+    mm = _StubMM([_WITH_CODE])
+
+    out = utils.mm_cc_all_hosts(mm, mm.cc_exitcode, "1", "foo")
+
+    assert out == _WITH_CODE  # sibling error row NOT dropped
+    assert mm._raise_errors is True  # restored after the call
+
+
+def test_mm_cc_exitcode_wait_picks_host_with_code_ignoring_sibling(monkeypatch):
+    monkeypatch.setattr(utils.time, "sleep", lambda *_: None)
+
+    # Sibling reports "no client" twice before the VM's host records the code.
+    mm = _StubMM([_SIBLING_ONLY, _SIBLING_ONLY, _WITH_CODE])
+
+    row = utils.mm_cc_exitcode_wait(mm, "1", "foo", grace=60.0, poll_rate=0.0)
+
+    assert row["Response"] == "0"
+    assert mm.calls == 3
+
+
+def test_mm_cc_exitcode_wait_transport_error_raises_immediately(monkeypatch):
+    monkeypatch.setattr(utils.time, "sleep", lambda *_: None)
+
+    # A permanent transport/namespace error (not a per-host data error) is not
+    # retried.
+    mm = _StubMM([minimega.Error("vm not found: foo")])
+
+    with pytest.raises(minimega.Error):
+        utils.mm_cc_exitcode_wait(mm, "1", "foo")
+
+    assert mm.calls == 1
+
+
+def test_mm_cc_exitcode_wait_grace_exceeded(monkeypatch):
+    monkeypatch.setattr(utils.time, "sleep", lambda *_: None)
+
+    # No host ever reports the code (e.g. the client never came back).
+    mm = _StubMM([_SIBLING_ONLY] * 5)
+
+    with pytest.raises(RuntimeError):
+        utils.mm_cc_exitcode_wait(mm, "1", "foo", grace=0.0, poll_rate=0.0)
+
+
+def test_mm_command_id_reads_data_field():
+    # minimega returns the new command id (an int) in the Data field; it must be
+    # stringified to match the string id in `cc commands` tabular output.
+    resp = [{"Host": "headnode", "Data": 36, "Error": ""}]
+
+    assert utils.mm_command_id(resp) == "36"
+
+
+def test_mm_command_id_picks_host_carrying_data():
+    # On multi-host, only the host that created the command carries Data; others
+    # may report Data=None. The id must still be found.
+    resp = [
+        {"Host": "gibson1337", "Data": None, "Error": ""},
+        {"Host": "gibson1336", "Data": 7, "Error": ""},
+    ]
+
+    assert utils.mm_command_id(resp) == "7"
+
+
+def test_mm_command_id_missing_data_raises():
+    with pytest.raises(RuntimeError):
+        utils.mm_command_id([{"Host": "headnode", "Data": None, "Error": ""}])

--- a/src/python/phenix_apps/common/utils.py
+++ b/src/python/phenix_apps/common/utils.py
@@ -340,6 +340,133 @@ def mm_get_cc_path(mm: minimega.minimega) -> Path | None:
     return cc_path
 
 
+# On a multi-host deployment, cc commands fan out to remote hosts over meshage.
+# Several conditions are transient, where a VM's miniccc client is briefly
+# unresolvable by name/uuid even though its command already completed.
+# These must be polled through, not treated as hard errors
+
+# seconds between polls
+CC_POLL_RATE = 1.0
+# bounded window to ride out a transient error after command has completed
+CC_EXITCODE_GRACE = 10.0
+
+# Mesh blips worth re-polling
+_MM_TRANSIENT = (
+    "no client",
+    "broken pipe",
+    "connection refused",
+    "connection reset",
+    "use of closed",
+    "i/o timeout",
+    "meshage",
+    "timeout",
+    "eof",
+)
+
+# Genuine errors that will never clear on retry
+_MM_PERMANENT = (
+    "vm not found",
+    "vm not running",
+    "cannot mesh send yourself",
+    "invalid command",
+    "no such handler",
+    "expected",  # minicli syntax errors ("expected ...")
+)
+
+
+def is_transient_mm_error(exc: Exception) -> bool:
+    """Report whether a minimega error is transient and worth re-polling"""
+    s = str(exc).lower()
+
+    if any(p in s for p in _MM_PERMANENT):
+        return False
+
+    return any(t in s for t in _MM_TRANSIENT)
+
+
+def mm_cc_all_hosts(mm: minimega.minimega, method, *args) -> list:
+    """Call an mm cc_* method and return ALL per-host response rows, without
+    raising on an individual host's error.
+
+    On a multi-host deployments, cc_exitcode / cc_responses fan out across the
+    namespace: the host running the VM returns the data while sibling hosts
+    report "no client <vm>" / "no responses for <id>". With raise_errors=True
+    (the binding default) _get_response raises on the FIRST host error and
+    discards the valid row, so we temporarily disable it and let the caller scan
+    every row.
+    """
+    saved = mm._raise_errors
+    mm._raise_errors = False
+
+    try:
+        return method(*args)
+    finally:
+        mm._raise_errors = saved
+
+
+def mm_cc_exitcode_wait(
+    mm: minimega.minimega,
+    cmd_id: str,
+    client: str,
+    grace: float = CC_EXITCODE_GRACE,
+    poll_rate: float = CC_POLL_RATE,
+) -> dict:
+    """Wait for and return the cc exit-code response row for an already-completed
+    command, tolerating multi-host fan-out.
+
+    cc_exitcode fans out across the namespace; only the host running the VM has
+    the code, while sibling hosts report "no client <vm>". Scan every host row
+    and return the one carrying the code, ignoring sibling errors (a sibling that
+    doesn't run the VM never will, so retrying its error is pointless). ``grace``
+    is the bounded window to ride out the brief gap between the command's
+    response becoming visible and the exit code being recorded; it raises
+    RuntimeError if no host reports the code within it.
+    """
+    deadline = time.monotonic() + grace
+
+    while True:
+        try:
+            rows = mm_cc_all_hosts(mm, mm.cc_exitcode, cmd_id, client)
+        except minimega.Error as ex:
+            # Transport/namespace-level failure (not a per-host data error).
+            if not is_transient_mm_error(ex):
+                raise
+
+            rows = []
+
+        for row in rows:
+            if not row.get("Error") and row.get("Response") not in (None, ""):
+                return row
+
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"timed out after {grace}s waiting for exit code of command "
+                f"{cmd_id} on {client}"
+            )
+
+        logger.warning(
+            f"exit code for {client} (cmd {cmd_id}) not yet reported by any host; "
+            f"retrying"
+        )
+        time.sleep(poll_rate)
+
+
+def mm_command_id(resp: list) -> str:
+    """Return the id of the command just created by cc_exec / cc_exec_once /
+    cc_send. minimega returns the new id in the response's ``Data`` field (see
+    Namespace.NewCommand), so read it from the call that created the command
+    rather than re-querying ``cc commands`` and guessing the last row -- the
+    latter is racy when another component issues into the same namespace queue.
+
+    The id is stringified to match the string id in ``cc commands`` tabular
+    output (compared in mm_wait_for_cmd)."""
+    for row in resp:
+        if row.get("Data") is not None:
+            return str(row["Data"])
+
+    raise RuntimeError(f"no command id in cc response: {resp!r}")
+
+
 def mm_exec_wait(
     mm: minimega.minimega,
     vm: str,
@@ -351,52 +478,37 @@ def mm_exec_wait(
 ) -> dict:
     mm.cc_filter(f"name={vm}")
 
-    if once:
-        mm.cc_exec_once(cmd)
-    else:
-        mm.cc_exec(cmd)
+    # Capture the new command's id directly from the cc_exec response rather than
+    # re-querying cc commands afterward.
+    resp = mm.cc_exec_once(cmd) if once else mm.cc_exec(cmd)
+    cmd_id = mm_command_id(resp)
 
-    last_cmd = mm_last_command(mm)
     mm_wait_for_cmd(
-        mm=mm, cmd_id=last_cmd["id"], timeout=timeout, poll_rate=poll_rate, debug=debug
+        mm=mm, cmd_id=cmd_id, timeout=timeout, poll_rate=poll_rate, debug=debug
     )
 
-    waiting = True
-    counter = 0
-
-    while waiting:
-        # we only expect a single response since scoped by VM
-        try:
-            exit_resp = mm.cc_exitcode(last_cmd["id"], vm)[0]
-            waiting = False
-            break
-        except minimega.Error as ex:
-            if not timeout:
-                raise ex from None
-
-        if timeout and counter > int(timeout / poll_rate):
-            raise RuntimeError(
-                f"Timeout exceeded waiting for exit code in mm.mm_exec_wait (timeout={timeout}, counter={counter}, poll_rate={poll_rate})"
-            ) from None
-
-        if debug:
-            print_msg(
-                f"Waiting {poll_rate} seconds before checking exit code for ID '{last_cmd['id']}' (timeout={timeout}, counter={counter})"
-            )
-
-        time.sleep(poll_rate)
-        counter += 1
+    # The command has completed (mm_wait_for_cmd saw a response). Fetch the exit
+    # code by UUID; mm_cc_exitcode_wait scans all hosts and ignores the sibling
+    # "no client" rows that the multi-host fan-out returns. Fall back to the VM
+    # name if the UUID lookup comes back empty.
+    uuid = mm_vm_uuid(mm, vm)
+    grace = timeout if timeout else CC_EXITCODE_GRACE
+    exit_resp = mm_cc_exitcode_wait(
+        mm, cmd_id, uuid or vm, grace=grace, poll_rate=poll_rate
+    )
 
     result = {
-        "id": last_cmd["id"],
-        "cmd": last_cmd["cmd"],
+        "id": cmd_id,
+        "cmd": cmd,
         "exitcode": int(exit_resp["Response"]),
         "stderr": None,
         "stdout": None,
     }
 
-    resps = mm.cc_responses(last_cmd["id"])
-    uuid = mm_vm_uuid(mm, vm)
+    # Read across all hosts: only the VM's host has the response; siblings report
+    # "no responses" and would otherwise raise. The loop below already skips rows
+    # with an empty Response.
+    resps = mm_cc_all_hosts(mm, mm.cc_responses, cmd_id)
 
     # example response from mm.cc_responses:
     # [{
@@ -428,6 +540,20 @@ def mm_exec_wait(
     return result
 
 
+def _mm_cc_commands_or_retry(mm: minimega.minimega) -> list | None:
+    """Return ``mm.cc_commands()`` output, or None if a transient multi-host mesh
+    error occurred (the caller should keep polling). Re-raises permanent errors."""
+    try:
+        return mm.cc_commands()
+    except minimega.Error as ex:
+        if not is_transient_mm_error(ex):
+            raise
+
+        logger.warning(f"transient error polling cc commands; retrying: {ex}")
+
+        return None
+
+
 def mm_wait_for_cmd(
     mm: minimega.minimega,
     cmd_id: str,
@@ -447,9 +573,9 @@ def mm_wait_for_cmd(
     while waiting:
         # >>> mm.cc_commands()
         # [{'Host': 'harmonie', 'Response': '', 'Header': ['id', 'prefix', 'command', 'responses', 'background', 'once', 'sent', 'received', 'connectivity', 'level', 'filter'], 'Tabular': [['1', 'testing', '[/usr/bin/iperf3 --version]', '15', 'false', 'true', '[]', '[]', '', '', 'os=linux && iperf=1']], 'Error': '', 'Data': None}]
-        commands = mm.cc_commands()
+        commands = _mm_cc_commands_or_retry(mm)
 
-        for host in commands:
+        for host in commands or []:
             last = list(filter(last_test, host["Tabular"]))
             done = list(filter(done_test, last))
 
@@ -491,9 +617,9 @@ def mm_wait_for_prefix(
     counter = 0
 
     while waiting:
-        commands = mm.cc_commands()
+        commands = _mm_cc_commands_or_retry(mm)
 
-        for host in commands:
+        for host in commands or []:
             last = list(filter(last_test, host["Tabular"]))
             done = list(filter(done_test, last))
 
@@ -516,7 +642,9 @@ def mm_wait_for_prefix(
 
 
 def mm_get_cc_responses(mm: minimega.minimega, id_or_prefix_or_all: str) -> list[dict]:
-    responses = mm.cc_responses(id_or_prefix_or_all)
+    # Read across all hosts so a sibling's "no responses" error doesn't abort the
+    # call; the loop below skips rows with an empty Response.
+    responses = mm_cc_all_hosts(mm, mm.cc_responses, id_or_prefix_or_all)
     results = []
 
     for row in responses:
@@ -545,15 +673,10 @@ def mm_get_cc_responses(mm: minimega.minimega, id_or_prefix_or_all: str) -> list
             if "stderr:\n" not in output and "stdout:\n" not in output:
                 print_msg(f"WARNING: no stderr or stdout in response: {output!r}")
 
-            try:
-                cmd_result["exitcode"] = int(
-                    mm.cc_exitcode(cmd_result["id"], cmd_result["uuid"])[0]["Response"]
-                )
-            except Exception:
-                time.sleep(1.0)
-                cmd_result["exitcode"] = int(
-                    mm.cc_exitcode(cmd_result["id"], cmd_result["uuid"])[0]["Response"]
-                )
+            # Fetch the exit code by UUID, polling through transient multi-host
+            # "no client" blips rather than a single blind retry.
+            exit_resp = mm_cc_exitcode_wait(mm, cmd_result["id"], cmd_result["uuid"])
+            cmd_result["exitcode"] = int(exit_resp["Response"])
 
             results.append(cmd_result)
 
@@ -561,6 +684,16 @@ def mm_get_cc_responses(mm: minimega.minimega, id_or_prefix_or_all: str) -> list
 
 
 def mm_last_command(mm: minimega.minimega) -> dict:
+    """DEPRECATED -- do not use in new code.
+
+    This infers "the command I just issued" as the last row of `cc commands`,
+    which is racy: the cc-command queue is shared across every component in the
+    namespace, so a concurrent (e.g. background) component can append a row
+    between your cc_exec/cc_send and this call. Prefer reading the id directly
+    from the cc call that created it: ``mm_command_id(mm.cc_send(...))`` /
+    ``mm_command_id(mm.cc_exec_once(...))``. Retained only for backwards
+    compatibility with out-of-tree callers.
+    """
     commands = mm.cc_commands()
 
     return {


### PR DESCRIPTION
# fix(mm): add stability for mm actions across hosts

## Description
Address stability across multi-node uses. Add both a timeout/retry for getting responses from the mesh, and the ability to scan across responses from multiple hosts and not fail on errors (when a host doesn't have a response even though the response may be fine, just on a different host.

Add unit tests cover these uses.

Add a deprecation notice to mm_last_command, and remove any calls here. This function isn't race-safe. I left in because I am not sure if any custom apps are using it.

> [!NOTE]
> I have 2 commits here, intentionally not squashed. The second is to fix an unrelated issue from #105 to make the format checks happy.

## Related Issue
N/A

## Type of Change
Please select the type of change your pull request introduces:
- [X] Bugfix
- ~New feature~
- ~Documentation update~
- ~Other (please describe):~

## Checklist
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [ ] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [X] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes
* Stability in the go apps needs to be addressed in upstream phenix/util/mm [sceptre-phenix#309](https://github.com/sandialabs/sceptre-phenix/pull/309)
* I want to do some heavy testing before marking ready, don't hold your breath