### PR TITLE
fix(helics): always enable root broker webserver (monitoring API)

### DIFF
--- a/src/python/phenix_apps/apps/helics/templates/broker.mako
+++ b/src/python/phenix_apps/apps/helics/templates/broker.mako
@@ -2,10 +2,10 @@
   <%
     if cfg.get('parent', None):
         opts = '--broker {} --local_interface {}'.format(cfg['parent'], cfg['endpoint'])
-    elif cfg.get('subs', 0):
-        opts = '--subbrokers {} --web --http_server_args="--http_port=8080 --external"'.format(cfg['subs'])
     else:
-        opts = ''
+        opts = '--web --http_server_args="--http_port=8080 --external"'
+        if cfg.get('subs', 0):
+            opts += ' --subbrokers {}'.format(cfg['subs'])
   %>\
 helics_broker \
   --name ${cfg['name']} \


### PR DESCRIPTION
## Description
The broker REST/web API (`--web --http_server_args="--http_port=8080 --external"`) is the federation's monitoring interface, but in `helics/templates/broker.mako` it was only added in the `elif cfg.get('subs', 0):` branch — i.e. only on a root broker that *has* sub-brokers. A flat topology (all federates connect directly to the root broker, so `subs == 0`) falls through to `else: opts = ''` and starts **no** webserver, leaving the federation unmonitorable (no `/current_state`, etc.).

This enables the webserver **unconditionally on the root broker** (the config without a `parent`), and appends `--subbrokers N` only when sub-brokers exist:
- Hierarchical topologies: unchanged behavior (root still gets `--subbrokers N` **and** `--web`).
- Flat topologies: root now serves the REST API.

## Related Issue
#112

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [ ] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes
- Webserver-on-root is sufficient for full-federation queries (`federate_map`, `global_state`, …) since they recurse to sub-brokers; no need to enable it on sub-brokers.
- Requires the `helics_broker` binary to be built with `HELICS_ENABLE_WEBSERVER`, otherwise `--web` is silently ignored (separate downstream/image concern).
- Pairs with #115 (broker readiness wait).
- Draft: not yet exercised against a live experiment.