### PR TITLE
fix(helics): wait for broker readiness instead of ping

### DIFF
--- a/src/python/phenix_apps/apps/helics/templates/wait_broker.mako
+++ b/src/python/phenix_apps/apps/helics/templates/wait_broker.mako
@@ -1,5 +1,10 @@
 #!/bin/bash
+# Wait for the root broker to actually accept connections, not merely respond
+# to ping (host reachable != helics_broker listening). Probe the broker
+# webserver port (8080) via bash /dev/tcp. Pairs with always enabling the root
+# broker webserver (see broker.mako).
 printf "%s" "waiting for root broker"
-time while ! ping -c 1 -n -w 1  ${rootbroker_ip} &> /dev/null; do 
+time until (exec 3<>"/dev/tcp/${rootbroker_ip}/8080") 2>/dev/null; do
     printf "%c" "."
+    sleep 1
 done

--- a/src/python/phenix_apps/apps/helics/templates/wait_broker.mako
+++ b/src/python/phenix_apps/apps/helics/templates/wait_broker.mako
@@ -1,10 +1,6 @@
 #!/bin/bash
-# Wait for the root broker to actually accept connections, not merely respond
-# to ping (host reachable != helics_broker listening). Probe the broker
-# webserver port (8080) via bash /dev/tcp. Pairs with always enabling the root
-# broker webserver (see broker.mako).
+# wait for the root broker to be up and accepting connections
 printf "%s" "waiting for root broker"
-time until (exec 3<>"/dev/tcp/${rootbroker_ip}/8080") 2>/dev/null; do
+time while ! nc -z -w1 ${rootbroker_ip} 23404 &> /dev/null; do
     printf "%c" "."
-    sleep 1
 done


### PR DESCRIPTION
## Description
`helics/templates/wait_broker.mako` waited for the broker with `ping -c 1 ... ${rootbroker_ip}`. A successful ping only means the broker *host* is reachable, not that `helics_broker` is *listening* — so federates can start before the broker accepts connections (masked only by the 30-minute HELICS connection timeout, a long/confusing failure window).

This keeps the original `while ! …` convention but probes the broker's ZMQ port with `nc` instead of pinging:

```bash
time while ! nc -z -w1 ${rootbroker_ip} 23404 &> /dev/null; do
    printf "%c" "."
done
```

## Related Issue
#113

## Type of Change
Please select the type of change your pull request introduces:
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [ ] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code.

## Additional Notes
- Probes the broker's default ZMQ port `23404` (`DEFAULT_ZMQ_PORT` in HELICS `networkDefaults.hpp`), which is what the root broker listens on (it is launched with no explicit `--port`). This is the port sub-brokers actually connect to — not `24000` (the sub-broker/federate port, nothing listens there on the root) and not the webserver port.
- **Requires `nc` (netcat) on the federate image** — the current federate image build does not install it, so netcat may need to be added.
- Pairs with #114 (always enable root webserver).
- Draft: not yet exercised against a live experiment.