### PR TITLE
feat (scale app): add delays to generated VMs

### DIFF
--- a/src/python/phenix_apps/apps/scale/app.py
+++ b/src/python/phenix_apps/apps/scale/app.py
@@ -208,6 +208,10 @@ echo 'DONE!'
         if "network" not in spec:
             spec["network"] = {"interfaces": []}
 
+        # Apply node_template delay if present
+        if "delay" in node_tmpl:
+            spec["delay"] = node_tmpl["delay"]
+
         # Apply node_template network override if present
         if "network" in node_tmpl:
             spec["network"] = node_tmpl["network"]


### PR DESCRIPTION
# feat: Specify scale app VM delays

## Description
This change allows you to pass a delay to generated scale app VMs like this:
```
            node_template:
              delay:
                c2:
                  - hostname: device-name
```

## Type of Change
Please select the type of change your pull request introduces:
- [~] Bugfix
- [x] New feature
- [~] Documentation update
- [~] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-phenix-apps/tree/main/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [~] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

